### PR TITLE
catch SIGTERM for graceful shutdown

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/coreos/go-systemd/activation"
 )
@@ -70,7 +71,7 @@ func onSocket(l net.Listener, socket string, srv *http.Server) {
 
 func catchInterrupt(srv *http.Server) {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, os.Kill)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 
 	s := <-c
 	log.Printf("caught %s: shutting down\n", s)


### PR DESCRIPTION
Unfortunately(?) it's not possible on any OS to actually catch/react on the KILL signal. What is typically used e.g. in k8s is SIG_TERM (aka CTRL-C). 

In theory this is not cross-platform (therefore not in the "os" package), but as it's supported on Linux,Mac,Windows that's normally not a problem,